### PR TITLE
Step 6: Files and Eval

### DIFF
--- a/oes6/core.js
+++ b/oes6/core.js
@@ -1,5 +1,7 @@
-import {malList, malNil} from './types.js'
+import {malList, malNil, malAtom, malString} from './types.js'
 import {pr_str} from './printer.js'
+import {read_str} from './reader.js'
+import * as fs from 'fs'
 
 const list = function (...args) {
   if (!args) {
@@ -78,6 +80,28 @@ const println = function (...args) {
   return malNil()
 }
 
+const file_reader = function (fileName) {
+  return malString(fs.readFileSync(fileName, 'utf8'))
+}
+
+const atom = arg => malAtom(arg)
+const is_atom = arg => typeof arg === 'object' && arg.type === 'atom'
+const deref = atom => atom.value
+const reset = function (atom, value) {
+  atom.value = value
+  return value
+}
+
+const swap = function (atom, func, ...funcs) {
+  const args = [atom.value, ...funcs]
+  if (typeof func === 'function') {
+    atom.value = func(...args)
+  } else {
+    atom.value = func.fn(...args)
+  }
+  return atom.value
+}
+
 export const ns = {
   '+': (a, b) => a + b,
   '-': (a, b) => a - b,
@@ -95,5 +119,12 @@ export const ns = {
   'pr-str': print_string,
   'str': str,
   'prn': prn,
-  'println': println
+  'println': println,
+  'read-string': read_str,
+  'slurp': file_reader,
+  'atom': atom,
+  'atom?': is_atom,
+  'deref': deref,
+  'reset!': reset,
+  'swap!': swap
 }

--- a/oes6/printer.js
+++ b/oes6/printer.js
@@ -18,6 +18,8 @@ export const pr_str = function (malObj, print_readably) {
         .replace(/"/g, `\\"`)}"`
     case 'object':
       switch (malObj.type) {
+        case 'atom':
+          return `(atom ${malObj.value})`
         case 'nil':
           return 'nil'
         case 'symbol':

--- a/oes6/reader.js
+++ b/oes6/reader.js
@@ -111,11 +111,11 @@ const read_list = function (reader) {
 
 const read_atom = function (reader) {
   const token = reader.peek()
-  if (/true/.test(token)) {
+  if (/^true$/.test(token)) {
     return true
-  } else if (/false/.test(token)) {
+  } else if (/^false$/.test(token)) {
     return false
-  } else if (/nil/.test(token)) {
+  } else if (/^nil$/.test(token)) {
     return malNil()
   } else if (/^:[a-zA-Z]+/.test(token)) {
     return malKeyword(token)

--- a/oes6/step6_file.js
+++ b/oes6/step6_file.js
@@ -1,0 +1,151 @@
+import {read_str} from './reader.js'
+import {pr_str} from './printer.js'
+import {malHashMap, malVector, malList, malNil, malSymbol, malFunction} from './types.js'
+import {Env} from './env.js'
+import {ns} from './core.js'
+
+const commandLineArgs = process.argv.slice(2)
+
+const repl_env = new Env(null)
+for (let symbol in ns) {
+  repl_env.set(malSymbol(symbol), ns[symbol])
+}
+repl_env.set(malSymbol('eval'), (ast) => EVAL(ast, repl_env))
+repl_env.set(malSymbol('*ARGV*'), malList(commandLineArgs.slice(1)))
+
+const eval_ast = function (ast, env) {
+  if (typeof ast === 'object') {
+    switch (ast.type) {
+      case 'symbol':
+        return env.get(ast)
+      case 'list':
+        return malList(...ast.map(element => EVAL(element, env)))
+      case 'vector':
+        return malVector(...ast.map(element => EVAL(element, env)))
+      case 'hashMap':
+        return malHashMap(ast[0], EVAL(ast[1], env))
+      default:
+        return ast
+    }
+  }
+  return ast
+}
+
+const _isSpecialForm = function (ast) {
+  return ast.length && ['def!', 'let*', 'fn*', 'do', 'if'].indexOf(ast[0].value) !== -1
+}
+
+const _isNil = ast => typeof ast === 'object' && ast.type === 'nil'
+
+const _isFalsy = ast => _isNil(ast) || ast === false
+
+const _isTruthy = ast => !_isFalsy(ast)
+
+const _isMalList = ast => typeof ast === 'object' && ast.type === 'list'
+
+const READ = arg => read_str(arg)
+const EVAL = function (ast, env) {
+  while (true) {
+    if (!_isMalList(ast)) {
+      return eval_ast(ast, env)
+    }
+    if (!ast.length) {
+      return ast
+    }
+    if (_isSpecialForm(ast)) {
+      const specialAtom = ast[0].value
+      switch (specialAtom) {
+        case 'def!':
+          const binds = ast[1]
+          const expres = EVAL(ast[2], env)
+          env.set(binds, expres)
+          return expres
+
+        case 'do':
+          const rest = ast.slice(1)
+          const last = rest.pop()
+          eval_ast(malList(...rest), env)
+          ast = last
+          continue
+
+        case 'if':
+          const condition = EVAL(ast[1], env)
+          if (_isTruthy(condition)) {
+            ast = ast[2]
+          } else if (ast[3] === undefined) {
+            return malNil()
+          } else {
+            ast = ast[3]
+          }
+          continue
+
+        case 'fn*':
+          const params = ast[1]
+          const body = ast[2]
+          const func = function (...args) {
+            const funcEnv = new Env(env, params, args)
+            return EVAL(body, funcEnv)
+          }
+          return malFunction(body, params, env, func)
+
+        case 'let*':
+          const newEnv = new Env(env)
+          if (ast[1].length % 2 !== 0) {
+            throw Error('The first argument of let* should be a malList with even objects')
+          }
+
+          while (ast[1].length) {
+            const [symb, val] = ast[1].splice(0, 2)
+            const evaluatedValue = EVAL(val, newEnv)
+            newEnv.set(symb, evaluatedValue)
+          }
+
+          env = newEnv
+          ast = ast[2]
+          continue
+      }
+    }
+
+    const evaluatedList = eval_ast(ast, env)
+    const [func, ...args] = evaluatedList
+    if (typeof func === 'function') {
+      return func(...args)
+    }
+    ast = func.ast
+    env = new Env(func.env, func.params, args)
+  }
+}
+
+const PRINT = arg => pr_str(arg, true)
+
+const rep = function (arg) {
+  const ast = READ(arg)
+  const result = EVAL(ast, repl_env)
+  return PRINT(result)
+}
+rep('(def! not (fn* (a) (if a false true)))')
+rep(`(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))`)
+if (commandLineArgs.length) {
+  rep(`(load-file "${commandLineArgs[0]}")`)
+  process.exit(0)
+}
+
+process.stdin.setEncoding('utf8')
+process.stdout.write('user> ')
+
+process.stdin.on('readable', function () {
+  const input = process.stdin.read()
+  if (input) {
+    let output
+    try {
+      output = rep(input.trim())
+    } catch (error) {
+      output = error.message
+    }
+    if (output !== undefined) {
+      process.stdout.write(output)
+      process.stdout.write('\n')
+    }
+    process.stdout.write('user> ')
+  }
+})

--- a/oes6/types.js
+++ b/oes6/types.js
@@ -43,12 +43,10 @@ export const malString = function (arg) {
             .replace(/\\\\/g, '\\')
 }
 
-export const malFunction = function (body, params, env, fn) {
-  return {
-    type: 'function',
-    ast: body,
-    params: params,
-    env: env,
-    fn: fn
-  }
+export const malFunction = function (ast, params, env, fn) {
+  return {ast, params, env, fn, type: 'function'}
+}
+
+export const malAtom = function (value) {
+  return {value, type: 'atom'}
 }


### PR DESCRIPTION
@quackingduck 

In this commit:
- Fixed regex that matches for `true`, `false`, `nil`
- Added a new Mal data type (`malAtom`)
- Added `slurp`a file reader
- Added functions related to atoms (`atom`, `atom?`, `swap!`, `deref`, `reset!`)
- Also added support for command line arguments when running a mal program, being the first argument the file to read.
- To see the changes between the previous repl: `diff -urp ./step5_tco.js ./step6_file.js`

Note: There is one test failing, 
`(def! a (atom 2))` expects and output of `(atom 2)`. See [this](https://github.com/kanaka/mal/pull/160)
# 

Update:
I modified the commit so that `def!` assigns a variable and returns the value of the newly assigned variable.
